### PR TITLE
Migrate unknownutil and std/testing to the latest version

### DIFF
--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "./deps.ts";
+import { assertEquals, assertRejects, test } from "./deps.ts";
 import * as popup from "./mod.ts";
 
 test({
@@ -50,7 +50,7 @@ test({
     await popup.close(denops, winid);
     assertEquals(state.closed, true);
     assertEquals(await popup.isVisible(denops, winid), false);
-    await assertThrowsAsync(async () => {
+    await assertRejects(async () => {
       await popup.info(denops, winid); // should throw error because the window already closed.
     });
   },

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { Denops, ensureNumber, load, once } from "./deps.ts";
+import { Denops, assertNumber, load, once } from "./deps.ts";
 
 const memo = <A extends unknown[], R extends Promise<unknown>>(
   f: (denops: Denops, ...args: A) => R,
@@ -66,7 +66,7 @@ export async function open(
   const winid = await denops.call("Denops_popup_window_open", bufnr, style, {
     onClose: [denops.name, onClose],
   });
-  ensureNumber(winid);
+  assertNumber(winid);
   return winid;
 }
 
@@ -118,7 +118,7 @@ export async function isVisible(
 ): Promise<boolean> {
   await init(denops);
   const is = await denops.call("Denops_popup_window_is_visible", winid);
-  ensureNumber(is);
+  assertNumber(is);
   return (is === 1) && isPopupWindow(denops, winid);
 }
 
@@ -133,7 +133,7 @@ export async function isPopupWindow(
 ): Promise<boolean> {
   await init(denops);
   const is = await denops.call("Denops_popup_window_is_popup_window", winid);
-  ensureNumber(is);
+  assertNumber(is);
   return is === 1;
 }
 


### PR DESCRIPTION
Encontered a compilation error with the latest deno (v1.21.2):
```
error: TS2322 [ERROR]: Type 'unknown' is not assignable to type 'number'.
  return winid;
  ~~~~~~~~~~~~~
    at https://deno.land/x/denops_popup@v2.1.0/mod.ts:72:3
```

This PR adopts to the following changes in dependencies:
- ensureXXXs are renamed to assertXXXs
- assertThrowsAsync has been abondoned (or just renamed?)

Comfirmed to pass the test in my local environment.