### PR TITLE
Improve import statements

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,0 @@
-export * from "https://deno.land/std/testing/asserts.ts";
-export * from "https://deno.land/x/denops_core/mod.ts";
-export * from "https://deno.land/x/denops_std/helper/mod.ts";
-export * from "https://deno.land/x/denops_std/anonymous/mod.ts";
-export * from "https://deno.land/x/denops_std/test/mod.ts";
-export * from "https://deno.land/x/unknownutil/mod.ts";

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,4 +1,5 @@
-import { assertEquals, assertRejects, test } from "./deps.ts";
+import { assertEquals, assertRejects } from "https://deno.land/std@0.138.0/testing/asserts.ts";;
+import { test } from "https://deno.land/x/denops_std@v3.3.1/test/mod.ts";
 import * as popup from "./mod.ts";
 
 test({

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrowsAsync, test } from "./deps.ts";
+import { assertEquals, assertRejects, test } from "./deps.ts";
 import * as popup from "./mod.ts";
 
 test({
@@ -50,7 +50,7 @@ test({
     await popup.close(denops, winid);
     assertEquals(state.closed, true);
     assertEquals(await popup.isVisible(denops, winid), false);
-    await assertThrowsAsync(async () => {
+    await assertRejects(async () => {
       await popup.info(denops, winid); // should throw error because the window already closed.
     });
   },

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { Denops, ensureNumber, load, once } from "./deps.ts";
+import { Denops, assertNumber, load, once } from "./deps.ts";
 
 const memo = <A extends unknown[], R extends Promise<unknown>>(
   f: (denops: Denops, ...args: A) => R,
@@ -66,7 +66,7 @@ export async function open(
   const winid = await denops.call("Denops_popup_window_open", bufnr, style, {
     onClose: [denops.name, onClose],
   });
-  ensureNumber(winid);
+  assertNumber(winid);
   return winid;
 }
 
@@ -118,7 +118,7 @@ export async function isVisible(
 ): Promise<boolean> {
   await init(denops);
   const is = await denops.call("Denops_popup_window_is_visible", winid);
-  ensureNumber(is);
+  assertNumber(is);
   return (is === 1) && isPopupWindow(denops, winid);
 }
 
@@ -133,7 +133,7 @@ export async function isPopupWindow(
 ): Promise<boolean> {
   await init(denops);
   const is = await denops.call("Denops_popup_window_is_popup_window", winid);
-  ensureNumber(is);
+  assertNumber(is);
   return is === 1;
 }
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,7 @@
-import { Denops, assertNumber, load, once } from "./deps.ts";
+import type { Denops } from "https://deno.land/x/denops_std@v3.3.1/mod.ts";
+import { load } from "https://deno.land/x/denops_std@v3.3.1/helper/mod.ts";
+import { once } from "https://deno.land/x/denops_std@v3.3.1/anonymous/mod.ts";
+import { assertNumber } from "https://deno.land/x/unknownutil@v2.0.0/mod.ts";
 
 const memo = <A extends unknown[], R extends Promise<unknown>>(
   f: (denops: Denops, ...args: A) => R,


### PR DESCRIPTION
- Add version numbers to all import statements
- Move the import statement for denops_std to mod.test.ts to avoid
  confliction of environment variables when denops-popup is used in
  another module
- Move the import statement std/testing since assertEquals and
  assertRejects are confusing with assertNumber
- Move the other statements to mod.ts and remove deps.ts since mod.ts
  and mod.test.ts do not have any shared dependency